### PR TITLE
Update binaryTarget to 0.10.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "xcode-selective-test",
-            url: "https://github.com/mikeger/XcodeSelectiveTesting/releases/download/0.9.6/xcode-selective-test.artifactbundle.zip",
-            checksum: "cd434a80775aafa9bc79211f266178f639a90520707b5c418dd265f6fdfd6824"
+            url: "https://github.com/mikeger/XcodeSelectiveTesting/releases/download/0.10.4/xcode-selective-test.artifactbundle.zip",
+            checksum: "ace369a0ef046f0133df70767fb8fadb89f93fccc5302f96439d69cf0058ac19"
         )
     ]
 )


### PR DESCRIPTION
Requires at least [0.10.1](https://github.com/mikeger/XcodeSelectiveTesting/releases/tag/0.10.1) to compile w/ Swift 6.